### PR TITLE
FIX: Update the ELT Pipeline Duplicate Data Exercise

### DIFF
--- a/lessons/ETLPipelines/11_duplicatedata_exercise/11_duplicatedata_exercise-solution.ipynb
+++ b/lessons/ETLPipelines/11_duplicatedata_exercise/11_duplicatedata_exercise-solution.ipynb
@@ -115,8 +115,8 @@
    "source": [
     "# Return Yugoslavia projects that might overlap with the other country projects\n",
     "yugoslavia = projects[(projects['countryname'].str.contains('Yugoslavia')) & \n",
-    "         (projects['boardapprovaldate'] > datetime.date(1980, 2, 1)) &\n",
-    "         (projects['boardapprovaldate'] < datetime.date(1989, 5, 23))][['regionname', \n",
+    "         (projects['boardapprovaldate'] >= datetime.date(1980, 2, 1)) &\n",
+    "         (projects['boardapprovaldate'] <= datetime.date(1989, 5, 23))][['regionname', \n",
     "                                                                   'countryname', \n",
     "                                                                   'lendinginstr', \n",
     "                                                                   'totalamt', \n",
@@ -143,7 +143,8 @@
     "\n",
     "* July 26th, 1983\n",
     "* March 31st, 1987\n",
-    "* October 13th, 1987"
+    "* October 13th, 1987\n",
+    "* May 23rd, 1989"
    ]
   },
   {

--- a/lessons/ETLPipelines/11_duplicatedata_exercise/11_duplicatedata_exercise.ipynb
+++ b/lessons/ETLPipelines/11_duplicatedata_exercise/11_duplicatedata_exercise.ipynb
@@ -124,7 +124,8 @@
     "\n",
     "* July 26th, 1983\n",
     "* March 31st, 1987\n",
-    "* October 13th, 1987"
+    "* October 13th, 1987\n",
+    "* May 23rd, 1989"
    ]
   },
   {


### PR DESCRIPTION
There were four overlapping dates when we compare with `>=` and `<=`