### PR TITLE
Fix broken requirement in lessons/WebDevelopment/AdvancedDataDashboardCode/world_bank_api_dashboard/requirements.txt

### DIFF
--- a/lessons/WebDevelopment/AdvancedDataDashboardCode/world_bank_api_dashboard/requirements.txt
+++ b/lessons/WebDevelopment/AdvancedDataDashboardCode/world_bank_api_dashboard/requirements.txt
@@ -10,7 +10,7 @@ itsdangerous==0.24
 Jinja2==2.10
 jsonschema==2.6.0
 jupyter-core==4.4.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 nbformat==4.4.0
 numpy==1.14.3
 pandas==0.22.0


### PR DESCRIPTION
Updated `lessons/WebDevelopment/AdvancedDataDashboardCode/world_bank_api_dashboard/requirements.txt`

Updated the MarkupSafe requirement to the current version as the previous stated version 1.0 broke for me when I pushed it to heroku. Using 1.1.1 fixes this issue for me.